### PR TITLE
Close and shutdown

### DIFF
--- a/lib/romeo/connection.ex
+++ b/lib/romeo/connection.ex
@@ -89,6 +89,10 @@ defmodule Romeo.Connection do
     end
   end
 
+  def disconnect({:close, from}, %{socket: socket, transport: transport} = conn) do
+    transport.disconnect({:close, from}, socket)
+    {:stop, {:shutdown, :closed}, conn}
+  end
   def disconnect(info, %{socket: socket, transport: transport} = conn) do
     transport.disconnect(info, socket)
     {:connect, :reconnect, reset_connection(conn)}

--- a/lib/romeo/connection.ex
+++ b/lib/romeo/connection.ex
@@ -50,7 +50,7 @@ defmodule Romeo.Connection do
       opts
       |> Keyword.put_new(:timeout, @timeout)
       |> Keyword.put_new(:transport, @default_transport)
-      |> Keyword.put(:owner, self)
+      |> Keyword.put_new(:owner, self)
 
     Connection.start_link(__MODULE__, struct(__MODULE__, opts))
   end

--- a/lib/romeo/connection.ex
+++ b/lib/romeo/connection.ex
@@ -121,7 +121,7 @@ defmodule Romeo.Connection do
     case transport.handle_message(info, conn) do
       {:ok, conn, stanza} ->
         stanza = Romeo.Stanza.Parser.parse(stanza)
-        Kernel.send(owner, {:stanza, stanza})
+        Kernel.send(owner, {:stanza, stanza, self})
         {:noreply, conn}
       {:error, _} = error ->
         {:disconnect, error, conn}


### PR DESCRIPTION
This will change the `Connection.close()` method to actually close and shutdown as describe in the docs. Without this, the connection will try to reconnect.
