### PR TITLE
Bugfix/monitor owner process

### DIFF
--- a/lib/romeo/connection.ex
+++ b/lib/romeo/connection.ex
@@ -97,6 +97,10 @@ defmodule Romeo.Connection do
     transport.disconnect({:close, from}, socket)
     {:stop, {:shutdown, :closed}, conn}
   end
+  def disconnect({:owner_down, reason}, %{socket: socket, transport: transport} = conn) do
+    transport.disconnect({:owner_down, reason}, socket)
+    {:stop, {:shutdown, {:owner_down, reason}}, conn}
+  end
   def disconnect(info, %{socket: socket, transport: transport} = conn) do
     transport.disconnect(info, socket)
     {:connect, :reconnect, reset_connection(conn)}


### PR DESCRIPTION
This fixes a bug when the caller is not the owner.

Romeo Connections link to the calling process so that if the caller exits the Romeo Connection exits.  

When Connections are managed by a supervisor (like in GCM) the Supervisor is the caller but the Pusher is the owner, the Connection was unaware of the owner process and the exit of that process did nothing to clean up the Connection.

This changes that behavior by monitoring the owner if it is different than the caller and implements some disconnect and cleanup logic on owner down.